### PR TITLE
fix: forward ticket_detection_config from GitAnalyzer to TicketExtractor

### DIFF
--- a/src/gitflow_analytics/cli_analysis_orchestrator.py
+++ b/src/gitflow_analytics/cli_analysis_orchestrator.py
@@ -444,6 +444,7 @@ def analyze(
             llm_config=llm_config,
             branch_analysis_config=branch_analysis_config,
             exclude_merge_commits=cfg.analysis.exclude_merge_commits,
+            ticket_detection_config=getattr(cfg.analysis, "ticket_detection", None),
         )
 
         # ------------------------------------------------------------------

--- a/src/gitflow_analytics/cli_identity_commands.py
+++ b/src/gitflow_analytics/cli_identity_commands.py
@@ -134,6 +134,7 @@ def identities(config: Path, weeks: int, apply: bool) -> None:
             llm_config=llm_config,
             branch_analysis_config=branch_analysis_config,
             exclude_merge_commits=cfg.analysis.exclude_merge_commits,
+            ticket_detection_config=getattr(cfg.analysis, "ticket_detection", None),
         )
 
         click.echo("Analyzing repositories for developer identities...")
@@ -355,6 +356,7 @@ def aliases_command(
             llm_config=llm_config,
             branch_analysis_config=branch_analysis_config,
             exclude_merge_commits=cfg.analysis.exclude_merge_commits,
+            ticket_detection_config=getattr(cfg.analysis, "ticket_detection", None),
         )
 
         all_commits = []

--- a/src/gitflow_analytics/core/analyzer.py
+++ b/src/gitflow_analytics/core/analyzer.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from git import Repo
 
@@ -15,6 +15,9 @@ from .analysis_components import (
 )
 from .cache import GitAnalysisCache
 from .progress import get_progress_service
+
+if TYPE_CHECKING:
+    from ..config.schema import TicketDetectionConfig
 
 # Get logger for this module
 logger = logging.getLogger(__name__)
@@ -40,6 +43,7 @@ class GitAnalyzer(GitAnalyzerMixin, CommitAnalyzerMixin):
         classification_config: Optional[dict[str, Any]] = None,
         branch_analysis_config: Optional[dict[str, Any]] = None,
         exclude_merge_commits: bool = False,
+        ticket_detection_config: Optional["TicketDetectionConfig"] = None,
     ):
         """Initialize analyzer with cache and optional ML categorization and commit classification.
 
@@ -55,6 +59,12 @@ class GitAnalyzer(GitAnalyzerMixin, CommitAnalyzerMixin):
             classification_config: Configuration for commit classification
             branch_analysis_config: Configuration for branch analysis optimization
             exclude_merge_commits: Exclude merge commits from filtered line count calculations
+            ticket_detection_config: Optional TicketDetectionConfig forwarded to the
+                ticket extractor so user-supplied ``analysis.ticket_detection.patterns``
+                / ``exclude_patterns`` / ``position`` settings are honored at analyze
+                time. Without this, the analyzer's in-memory ticket re-extraction
+                (the "Analyzing commits for tickets" pass) silently falls back to
+                hard-coded defaults, producing different results from GitDataFetcher.
         """
         self.cache = cache
         self.batch_size = batch_size
@@ -65,6 +75,7 @@ class GitAnalyzer(GitAnalyzerMixin, CommitAnalyzerMixin):
             ml_config=ml_categorization_config,
             llm_config=llm_config,
             cache_dir=cache.cache_dir / "ml_predictions",
+            ticket_detection_config=ticket_detection_config,
         )
         self.branch_mapper = build_branch_mapper(branch_mapping_rules)
         self.exclude_paths = exclude_paths or []

--- a/src/gitflow_analytics/pipeline_report.py
+++ b/src/gitflow_analytics/pipeline_report.py
@@ -240,6 +240,7 @@ def run_report(
         llm_config=llm_cfg,
         branch_analysis_config=branch_analysis_config,
         exclude_merge_commits=cfg.analysis.exclude_merge_commits,
+        ticket_detection_config=getattr(cfg.analysis, "ticket_detection", None),
     )
 
     _emit("Loading cached PRs from database...")

--- a/src/gitflow_analytics/training/pipeline.py
+++ b/src/gitflow_analytics/training/pipeline.py
@@ -219,6 +219,7 @@ class CommitClassificationTrainer:
                 self.config.analysis, "allowed_ticket_platforms", None
             ),
             story_point_patterns=getattr(self.config.analysis, "story_point_patterns", None),
+            ticket_detection_config=getattr(self.config.analysis, "ticket_detection", None),
         )
 
         for repo_config in repositories:

--- a/tests/core/test_analyzer.py
+++ b/tests/core/test_analyzer.py
@@ -28,6 +28,61 @@ class TestGitAnalyzer:
         assert analyzer.batch_size == 1000
         assert analyzer.exclude_paths == []
 
+    def test_ticket_detection_config_is_forwarded_to_extractor(self, temp_dir):
+        """Custom ticket_detection patterns must reach the analyzer's TicketExtractor.
+
+        Regression test: GitAnalyzer's in-memory ticket re-extraction (the
+        "Analyzing commits for tickets" pass) used to silently fall back to the
+        hard-coded default patterns because ticket_detection_config was never
+        forwarded to build_ticket_extractor(). That caused user-supplied
+        ``analysis.ticket_detection.patterns`` (e.g. an Azure DevOps ``AB#NNNN``
+        regex) to be ignored during analyze, while GitDataFetcher honored them
+        at fetch time -- producing inconsistent ticket-coverage numbers between
+        a fresh fetch and a cached re-run.
+        """
+        from gitflow_analytics.config.schema import TicketDetectionConfig
+
+        cache = GitAnalysisCache(temp_dir / ".gitflow-cache")
+
+        # Custom pattern that overrides the github default (#(\d+)) and matches
+        # only a distinctive token that the default regex cannot match.
+        custom_pattern = r"\bABCD-(\d+)\b"
+        td_cfg = TicketDetectionConfig(
+            patterns={"github": custom_pattern},
+            exclude_patterns=[],
+        )
+
+        analyzer = GitAnalyzer(cache, ticket_detection_config=td_cfg)
+
+        # The github pattern in the analyzer's extractor must be the custom one.
+        github_patterns = [
+            p.pattern for p in analyzer.ticket_extractor.compiled_patterns.get("github", [])
+        ]
+        assert github_patterns == [
+            custom_pattern
+        ], f"Expected custom github pattern to be forwarded, got: {github_patterns}"
+
+        # Behavior: the custom pattern matches its token, the old default does not.
+        msg = "Implements ABCD-42 across the codebase"
+        ticket_ids = [t["id"] for t in analyzer.ticket_extractor.extract_from_text(msg)]
+        assert "42" in ticket_ids
+
+        # And the default github "#(\\d+)" no longer applies, so a bare "#99"
+        # in the message is NOT picked up under the custom github pattern.
+        msg2 = "See #99 for context"
+        ticket_ids2 = [t["id"] for t in analyzer.ticket_extractor.extract_from_text(msg2)]
+        assert "99" not in ticket_ids2
+
+    def test_ticket_detection_config_default_is_backward_compatible(self, temp_dir):
+        """Without ticket_detection_config the analyzer behaves as before."""
+        cache = GitAnalysisCache(temp_dir / ".gitflow-cache")
+        analyzer = GitAnalyzer(cache)
+
+        # The default github pattern (#(\\d+)) should still match.
+        msg = "Closes #1234 final cleanup"
+        ticket_ids = [t["id"] for t in analyzer.ticket_extractor.extract_from_text(msg)]
+        assert "1234" in ticket_ids
+
     @patch("gitflow_analytics.core.analyzer.Repo")
     def test_analyze_repository_basic(self, mock_repo_class, temp_dir):
         """Test basic repository analysis functionality."""


### PR DESCRIPTION
## Summary

`GitAnalyzer.__init__` builds its in-memory `TicketExtractor` *without* forwarding `ticket_detection_config`. As a result the analyze-stage re-extraction (the `Analyzing commits for tickets` pass) silently falls back to the hard-coded default platform patterns (`jira` / `github` / `clickup` / `linear`), ignoring whatever the user supplied under `analysis.ticket_detection.patterns`, `exclude_patterns`, or `position` in the YAML config.

`GitDataFetcher` already forwards the config correctly ([`core/data_fetcher.py:84`](https://github.com/bobmatnyc/gitflow-analytics/blob/main/src/gitflow_analytics/core/data_fetcher.py#L84)), so the bug only surfaces on **cache-hit re-runs** where data fetching is skipped and the in-memory extractor's defaults take over. Coverage numbers and platform attribution between a fresh fetch and a cached re-run diverge for any user with custom patterns.

### Buggy call site

[`src/gitflow_analytics/core/analyzer.py:63-68`](https://github.com/bobmatnyc/gitflow-analytics/blob/main/src/gitflow_analytics/core/analyzer.py#L63-L68):

\`\`\`python
self.ticket_extractor = build_ticket_extractor(
    allowed_platforms=allowed_ticket_platforms,
    ml_config=ml_categorization_config,
    llm_config=llm_config,
    cache_dir=cache.cache_dir / "ml_predictions",
    # ticket_detection_config is missing here
)
\`\`\`

### Real-world impact

Analyzing a 26-repo Azure DevOps codebase with custom \`AB#NNNN\` / \`NNNNNN-\` patterns, the official report shows **39.8% ticket coverage**, but a direct call to \`TicketExtractor\` instantiated from the same config produces **60.7%**. The user-supplied config is silently ignored on every cached run.

### Reproduction

1. Set \`analysis.ticket_detection.patterns: { github: '\\\\bABCD-(\\\\d+)\\\\b' }\` and \`ticket_platforms: [github]\` in config.yaml.
2. Run \`gitflow-analytics analyze\` against a repo whose commits contain \`ABCD-NN\` references but no \`#NN\` references.
3. **Fresh run** (\`--clear-cache\`): tickets extracted via the custom regex; coverage > 0%.
4. **Cached re-run** (no flags): the same config produces *default-regex* coverage instead — \`#NN\` matches everywhere, custom regex appears unused.

## Fix

- Thread \`ticket_detection_config\` through \`GitAnalyzer.__init__\` to \`build_ticket_extractor()\`, matching the existing pattern in \`GitDataFetcher\`.
- Update the five \`GitAnalyzer(...)\` call sites (\`pipeline_report\`, \`cli_analysis_orchestrator\`, \`cli_identity_commands\` ×2, \`training.pipeline\`) to pass \`cfg.analysis.ticket_detection\`.
- Adds two regression tests in \`tests/core/test_analyzer.py\`: one verifying custom patterns reach the extractor, one confirming default-config backward compatibility.

## Test plan

- [x] \`pytest tests/core/test_analyzer.py -v\` — 11 passed (2 new + 9 existing)
- [x] \`pytest tests/core/ tests/extractors/\` — 255 passed
- [x] Verified the new regression test fails on unfixed code with \`TypeError: GitAnalyzer.__init__() got an unexpected keyword argument 'ticket_detection_config'\`
- [x] \`ruff check\` clean on changed files
- [x] \`black --check\` clean on changed files (pre-existing formatting drift in unrelated lines was deliberately not touched, to keep the diff focused on the fix)

## Notes

The bug only surfaces on cache-hit re-runs because \`GitDataFetcher\` (which runs on cache miss) already forwards the config correctly. First-time analyses see correct coverage; the divergence appears on the second run unless \`--clear-cache\` is used. This makes the bug easy to miss in development but consistently misleading in long-lived deployments.