### PR TITLE
fix: use timedelta in pr_reporting test fixture to avoid month overflow

### DIFF
--- a/tests/reports/test_pr_reporting.py
+++ b/tests/reports/test_pr_reporting.py
@@ -12,7 +12,7 @@ Covers:
 from __future__ import annotations
 
 import csv
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from io import StringIO
 from pathlib import Path
 from typing import Any
@@ -105,8 +105,8 @@ def review_prs(recent_date: datetime) -> list[dict[str, Any]]:
             "title": "Add tests",
             "author": "bob",
             "canonical_id": "bob@example.com",
-            "created_at": recent_date.replace(day=recent_date.day + 1),
-            "merged_at": recent_date.replace(day=recent_date.day + 1, hour=14),
+            "created_at": recent_date + timedelta(days=1),
+            "merged_at": (recent_date + timedelta(days=1)).replace(hour=14),
             "additions": 150,
             "deletions": 0,
             "changed_files": 6,
@@ -126,8 +126,8 @@ def review_prs(recent_date: datetime) -> list[dict[str, Any]]:
             "title": "Update docs",
             "author": "alice",
             "canonical_id": "alice@example.com",
-            "created_at": recent_date.replace(day=recent_date.day + 2),
-            "merged_at": recent_date.replace(day=recent_date.day + 2, hour=11),
+            "created_at": recent_date + timedelta(days=2),
+            "merged_at": (recent_date + timedelta(days=2)).replace(hour=11),
             "additions": 30,
             "deletions": 5,
             "changed_files": 2,


### PR DESCRIPTION
## Summary
- `tests/reports/test_pr_reporting.py` constructed PR `created_at`/`merged_at` values via `recent_date.replace(day=recent_date.day + N)`. When the base date landed on the last 1-2 days of a month, `day + N` exceeded the month length and raised `ValueError: day is out of range for month`.
- Replace the four buggy sites with `recent_date + timedelta(days=N)`, which carries day overflow across month boundaries correctly.

## When the bug fired
The fixture is `datetime.now(timezone.utc) - timedelta(days=7)`. The bug surfaces whenever today minus 7 lands on day 30 or 31 of a 30-day month, or day 29/30/31 of February:

| Today | `recent_date` (today − 7) | `day + 2` | Result |
|-------|---------------------------|-----------|--------|
| May 6 | Apr 29 | day=31 | ❌ April has 30 days |
| May 7 | Apr 30 | day=32 | ❌ April has 30 days |
| Jun 6 | May 30 | day=32 | ❌ |
| Jun 7 | May 31 | day=33 | ❌ |
| Mar 6 (non-leap) | Feb 27 | day=29 | ❌ Feb has 28 |

Roughly two days per month silently broke `test_pr_reporting.py`.

## Test plan
- [x] `pytest tests/reports/test_pr_reporting.py -q` — was 25 passed + 17 errors, now 42 passed, 0 errors
- [x] No behavior change to production code (test-only fix)
- [x] Diff is minimal: only the four buggy `day=day+N` sites; absolute `day=2` / `day=5` calls left alone

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)